### PR TITLE
DSFAAP-452: enable production-like runs for testing

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
       - PORT=80
       - REDIS_HOST=redis
       - NODE_ENV=development
+      - ENABLE_SECURE_CONTEXT=1
 
   redis:
     image: redis:7.2.3-alpine3.18


### PR DESCRIPTION
For some reason, we've not been able to use the `NODE_ENV=production` in github actions (instead using development) since we've enabled CSRF.

We want these tests to run in as production-like conditions as possible, so we're trying to locate the flag that makes the difference.

As a strategy, I'm looking to enabling production-implied flags one by one, to find what's causing the issue.